### PR TITLE
Adds Social Share image generation submodule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "type": "library",
   "version": "1.0.0-alpha-15",
   "require-dev": {
+    "chrome-php/chrome": "^1.15",
     "laravel/framework": "^12.0 || ^13.0",
     "pestphp/pest": "^4.5",
     "larastan/larastan": "^3.9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,732 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5e00746da6a2f15d314acd26b7a3cd1",
-    "packages": [],
+    "content-hash": "14f5448b2993d9e43f6619d9d6fdd85c",
+    "packages": [
+        {
+            "name": "chrome-php/chrome",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chrome-php/chrome.git",
+                "reference": "5b2ee677f34ed4cd9463e49dc59c4989d0fe40f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chrome-php/chrome/zipball/5b2ee677f34ed4cd9463e49dc59c4989d0fe40f3",
+                "reference": "5b2ee677f34ed4cd9463e49dc59c4989d0fe40f3",
+                "shasum": ""
+            },
+            "require": {
+                "chrome-php/wrench": "^1.8",
+                "evenement/evenement": "^3.0.1",
+                "monolog/monolog": "^1.27.1 || ^2.8 || ^3.2",
+                "php": "^7.4.15 || ^8.0.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^9.6.3 || ^10.0.12",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "HeadlessChromium\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Enrico Dias",
+                    "email": "enrico@enricodias.com",
+                    "homepage": "https://github.com/enricodias"
+                }
+            ],
+            "description": "Instrument headless chrome/chromium instances from PHP",
+            "keywords": [
+                "browser",
+                "chrome",
+                "chromium",
+                "crawl",
+                "headless",
+                "pdf",
+                "puppeteer",
+                "screenshot"
+            ],
+            "support": {
+                "issues": "https://github.com/chrome-php/chrome/issues",
+                "source": "https://github.com/chrome-php/chrome/tree/v1.15.0"
+            },
+            "time": "2025-12-27T12:23:40+00:00"
+        },
+        {
+            "name": "chrome-php/wrench",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chrome-php/wrench.git",
+                "reference": "bd67a315cf2143ba30598339ad1b6c346db96c99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chrome-php/wrench/zipball/bd67a315cf2143ba30598339ad1b6c346db96c99",
+                "reference": "bd67a315cf2143ba30598339ad1b6c346db96c99",
+                "shasum": ""
+            },
+            "require": {
+                "ext-sockets": "*",
+                "php": "^7.4.15 || ^8.0.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/polyfill-php80": "^1.26"
+            },
+            "conflict": {
+                "wrench/wrench": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^9.6.3 || ^10.0.12"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wrench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "A simple PHP WebSocket implementation",
+            "keywords": [
+                "WebSockets",
+                "hybi",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/chrome-php/wrench/issues",
+                "source": "https://github.com/chrome-php/wrench/tree/v1.8.0"
+            },
+            "time": "2025-12-27T11:29:35+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:39:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "ajthinking/archetype",
@@ -3642,109 +4366,6 @@
             "time": "2024-05-16T03:13:13+00:00"
         },
         {
-            "name": "monolog/monolog",
-            "version": "3.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
-                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/log": "^2.0 || ^3.0"
-            },
-            "provide": {
-                "psr/log-implementation": "3.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^3.0",
-                "doctrine/couchdb": "~1.0@dev",
-                "elasticsearch/elasticsearch": "^7 || ^8",
-                "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2.0",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8 || ^2.0",
-                "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "php-console/php-console": "^3.1.8",
-                "phpstan/phpstan": "^2",
-                "phpstan/phpstan-deprecation-rules": "^2",
-                "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
-                "predis/predis": "^1.1 || ^2",
-                "rollbar/rollbar": "^4.0",
-                "ruflin/elastica": "^7 || ^8",
-                "symfony/mailer": "^5.4 || ^6",
-                "symfony/mime": "^5.4 || ^6"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
-                "ext-mbstring": "Allow to work properly with unicode symbols",
-                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
-                "ext-openssl": "Required to send log messages using SSL",
-                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "https://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "https://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "support": {
-                "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Seldaek",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-01-02T08:56:05+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -6488,56 +7109,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -9786,89 +10357,6 @@
             "time": "2026-03-30T15:14:47+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.34.0",
             "source": {
@@ -10121,175 +10609,6 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
@@ -10613,71 +10932,6 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v8.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
-                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -12675,5 +12929,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/sitekit.php
+++ b/config/sitekit.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Social Share image generation
+    |--------------------------------------------------------------------------
+    |
+    | Here you configure how the headless Chrome instance us used to create
+    | screenshots of the social share templates. It is possible to cache
+    | the images as well as control the lock used in generating them.
+    |
+    */
+    'social_share' => [
+
+        'chrome_path' => env('SITEKIT_SOCIAL_SHARE_CHROME_PATH', '/usr/bin/chromium'),
+        'render_url' => env('SITEKIT_SOCIAL_SHARE_RENDER_URL', 'http://localhost:8000'),
+        'window_size' => env('SITEKIT_SOCIAL_SHARE_WINDOW_SIZE', '1200x840'),
+
+        'entry_mixins' => [
+            \FewFar\Sitekit\Database\QueryMixins\WherePageIsPublished::class,
+            \FewFar\Sitekit\Database\QueryMixins\WherePageIsVisible::class,
+        ],
+
+        'cache' => [
+            'enabled' => env('SITEKIT_SOCIAL_SHARE_CACHE_ENABLED', true),
+            'disk' => env('SITEKIT_SOCIAL_SHARE_CACHE_DISK', null),
+        ],
+
+        'lock' => [
+            'name' => env('SITEKIT_SOCIAL_SHARE_LOCK_NAME', 'sitekit/social-share'),
+            'expiry_seconds' => env('SITEKIT_SOCIAL_SHARE_LOCK_EXPIRE', 61),
+            'block_seconds' => env('SITEKIT_SOCIAL_SHARE_LOCK_BLOCK', 10),
+        ],
+    ],
+];

--- a/src/Database/QueryMixins/WherePageIsIndexable.php
+++ b/src/Database/QueryMixins/WherePageIsIndexable.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FewFar\Sitekit\Database\QueryMixins;
+
+use Illuminate\Support\Facades\DB;
+
+class WherePageIsIndexable
+{
+    public ?string $table = null;
+
+    public function setTable(?string $table)
+    {
+        $this->table = $table;
+
+        return $table;
+    }
+
+    public function __invoke($query)
+    {
+        $segments = [
+            when($this->table, $query->getGrammar()->wrap(...)),
+            'COALESCE("data"->>\'page_meta_noindex\', \'\')',
+        ];
+
+        $column = collect($segments)->filter()->implode('.');
+
+        return $query->where(DB::raw($column), '!=', 'true');
+    }
+}

--- a/src/Database/QueryMixins/WherePageIsPublished.php
+++ b/src/Database/QueryMixins/WherePageIsPublished.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FewFar\Sitekit\Database\QueryMixins;
+
+use Illuminate\Support\Facades\DB;
+
+class WherePageIsPublished
+{
+    public function __invoke($query)
+    {
+        return $query->whereStatus('published');
+    }
+}

--- a/src/Database/QueryMixins/WherePageIsVisible.php
+++ b/src/Database/QueryMixins/WherePageIsVisible.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FewFar\Sitekit\Database\QueryMixins;
+
+use Illuminate\Support\Facades\DB;
+
+class WherePageIsVisible
+{
+    public ?string $table = null;
+
+    public function setTable(?string $table)
+    {
+        $this->table = $table;
+
+        return $table;
+    }
+
+    public function prefix($query)
+    {
+        if (! $this->table) {
+            return '';
+        }
+
+        return $query->getGrammar()->wrap($this->table) . '.';
+    }
+
+    public function __invoke($query)
+    {
+        $prefix = $this->prefix($query);
+
+        return $query
+            ->where(function ($query) use ($prefix) {
+                $query->orWhereRaw($prefix . 'data->\'expiry_redirect\' IS NULL');
+                $query->orWhereRaw($prefix . 'data->\'expiry_date\' IS NULL');
+                $query->orWhereRaw($prefix . 'data->>\'expiry_date\' > ?', [now()]);
+            })
+            ->where(DB::raw('COALESCE(' . $prefix . 'data->>\'protect\', \'\')'), '!=', 'password');
+    }
+}

--- a/src/SitekitServiceProvider.php
+++ b/src/SitekitServiceProvider.php
@@ -13,6 +13,17 @@ class SitekitServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->registerConfig();
+        $this->registerServiceProviders();
+    }
+
+    public function registerConfig()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/sitekit.php', 'sitekit');
+    }
+
+    public function registerServiceProviders()
+    {
         $this->app->register(MonkeyPatch\MonkeyPatchServiceProvider::class);
         $this->app->register(Redirects\RedirectServiceProvider::class);
         $this->app->register(Forms\FormsServiceProvider::class);
@@ -20,5 +31,6 @@ class SitekitServiceProvider extends ServiceProvider
         $this->app->register(ViewModels\ViewModelsServiceProvider::class);
         $this->app->register(Imaging\ImagingServiceProvider::class);
         $this->app->register(Support\SupportServiceProvider::class);
+        $this->app->register(SocialShare\SocialShareServiceProvider::class);
     }
 }

--- a/src/SocialShare/CleanupCommand.php
+++ b/src/SocialShare/CleanupCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use Illuminate\Console\Command;
+
+class CleanupCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sitekit:social-share:clear {--force}';
+
+    /**
+     * Create an instance of the command.
+     */
+    public function __construct(
+        protected ImageGenerator $images
+    )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Run the command.
+     */
+    public function handle()
+    {
+        $this->info(' Social Share cache directory exists at:');
+        $this->comment(' ' . $this->images->storage()->path('social-share/'));
+        $this->newLine();
+
+        if (! $this->shouldRun()) {
+            return;
+        }
+
+        $this->images->clear();
+
+        $this->info(' Directory removed.');
+    }
+
+    /**
+     * Get force or ask permission from user.
+     */
+    protected function shouldRun()
+    {
+        if ($this->option('force')) {
+            return true;
+        }
+
+        return $this->confirm('Are you sure you want to delete this directory?');
+    }
+}

--- a/src/SocialShare/EntryFinder.php
+++ b/src/SocialShare/EntryFinder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use Statamic\Facades;
+
+class EntryFinder
+{
+    /**
+     * Locate the entry by ID
+     *
+     * @param string|int|null  $id
+     * @return \Statamic\Contracts\Entries\Entry
+     */
+    public function find($id)
+    {
+        $query = $this->query();
+
+        foreach ($this->mixins() as $mixin) {
+            $query->tap($mixin);
+        }
+
+        return $query->find($id);
+    }
+
+    /**
+     * Create an instance of the query builder.
+     */
+    public function query()
+    {
+        return Facades\Entry::query();
+    }
+
+    /**
+     * Collect all the Mixins or Scopes for entries.
+     */
+    public function mixins()
+    {
+        return collect(config('sitekit.social_share.entry_mixins'))->map(function ($mixin) {
+            if (is_string($mixin) && class_exists($mixin)) {
+                return app($mixin);
+            }
+
+            if (is_string($mixin)) {
+                return \Statamic\Facades\Scope::find($mixin);
+            }
+
+            return $mixin;
+        });
+    }
+}

--- a/src/SocialShare/HandleImageCleanup.php
+++ b/src/SocialShare/HandleImageCleanup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use Statamic\Events\EntryDeleted;
+use Statamic\Events\EntrySaved;
+
+class HandleImageCleanup
+{
+    /**
+     * Register events.
+     */
+    public function subscribe()
+    {
+        if (! config('sitekit.social_share.cache.enabled')) {
+            return null;
+        }
+
+        return [
+            EntrySaved::class => 'handleSaved',
+            EntryDeleted::class => 'handleDeleted',
+        ];
+    }
+
+    /**
+     * Remove cached images if the Entry has changed.
+     */
+    public function handleSaved(EntrySaved $event, ImageGenerator $generator)
+    {
+        if ($generator->storage()->exists($generator->screenshotPath($event->entry))) {
+            return;
+        }
+
+        $generator->cleanup($event->entry);
+    }
+
+    /**
+     * Remove cached images when Entry is deleted.
+     */
+    public function handleDeleted(EntryDeleted $event, ImageGenerator $generator)
+    {
+        $generator->cleanup($event->entry);
+    }
+}

--- a/src/SocialShare/HtmlController.php
+++ b/src/SocialShare/HtmlController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use FewFar\Sitekit\ViewModels\Listeners\CreatePageModel;
+use Illuminate\Http\Request;
+use Statamic\Facades\Entry;
+
+class HtmlController
+{
+    /**
+     * Render the Entry's social share template.
+     */
+    public function __invoke(Request $request, EntryFinder $entries)
+    {
+        $entry = $entries->find($request->route('id')) ?? abort(404);;
+
+        return app(CreatePageModel::class)
+            ->mapper($entry)
+            ->socialShareView() ?? abort(404);
+    }
+}

--- a/src/SocialShare/ImageController.php
+++ b/src/SocialShare/ImageController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use Illuminate\Http\Request;
+use Statamic\Contracts\Entries\Entry;
+
+class ImageController
+{
+    /**
+     * Creates an instance of the controller.
+     */
+    public function __construct(
+        protected ImageGenerator $images
+    )
+    {
+    }
+
+    /**
+     * Return the social share image, either using the cache or generating a new.
+     */
+    public function __invoke(Request $request, EntryFinder $entries)
+    {
+        $entry = $entries->find($request->route('id')) ?? abort(404);;
+
+        $this->handleHashRedirect($entry, $request->query('hash'));
+
+        return response()
+            ->make($this->images->image($entry))
+            ->header('Content-Type', 'image/webp');
+    }
+
+    /**
+     * Checks to see if the has is the latest, redirecting if not.
+     *
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException if hash provided is not the latest.
+     */
+    protected function handleHashRedirect(Entry $entry, ?string $hash)
+    {
+        if (! $hash) {
+            return;
+        }
+
+        $latest = $this->images->screenshotHash($entry);
+
+        if ($hash === $latest) {
+            return;
+        }
+
+        $url = url()->signedRoute('sitekit.social-share', [
+            'id' => $entry->id(),
+            'hash' => $latest,
+        ]);
+
+        abort(response()->redirectTo($url));
+    }
+}

--- a/src/SocialShare/ImageGenerator.php
+++ b/src/SocialShare/ImageGenerator.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use FewFar\Sitekit\ViewModels\Listeners\CreatePageModel;
+use HeadlessChromium\Browser\ProcessAwareBrowser;
+use HeadlessChromium\BrowserFactory;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Statamic\Contracts\Entries\Entry;
+
+class ImageGenerator
+{
+    /**
+     * Get cached or create a new Social Share image.
+     */
+    public function image(Entry $entry)
+    {
+        if ($image = $this->cachedImage($entry)) {
+            return $image;
+        }
+
+        $image = $this->lock(function () use ($entry) {
+            return $this->screenshot($this->htmlUrl($entry))->getRawBinary();
+        });
+
+        $this->storage()->put($this->screenshotPath($entry), $image);
+
+        return $image;
+    }
+
+    /**
+     * Finds the cached version, if enabled.
+     */
+    public function cachedImage(Entry $entry)
+    {
+        if (! config('sitekit.social_share.cache.enabled')) {
+            return null;
+        }
+
+        return $this->storage()->get($this->screenshotPath($entry));
+    }
+
+    /**
+     * Delete all social share images for all Entries.
+     */
+    public function clear()
+    {
+        return $this->storage()->deleteDirectory('social-share/entries/');
+    }
+
+    /**
+     * Delete all social share images for the given Entry
+     */
+    public function cleanup(Entry $entry)
+    {
+        return $this->storage()->deleteDirectory($this->screenshotFolder($entry));
+    }
+
+    /**
+     * Configured Filesystem via container.
+     */
+    public function storage()
+    {
+        return Storage::disk(config('sitekit.social_share.disk'));
+    }
+
+    /**
+     * Screenshot folder for Entry, relative to storage disk.
+     */
+    public function screenshotFolder(Entry $entry)
+    {
+        return 'social-share/entries/' . $entry->id() . '/';
+    }
+
+    /**
+     * Screenshot path for Entry, relative to storage disk.
+     */
+    public function screenshotPath(Entry $entry)
+    {
+        return $this->screenshotFolder($entry) . $this->screenshotHash($entry) . '.webp';
+    }
+
+    /**
+     * Uses social share data from Entry's mapper to generate a sha1.
+     */
+    public function screenshotHash(Entry $entry)
+    {
+        return sha1(json_encode($this->screenshotHashData($entry)));
+    }
+
+    /**
+     * Use the Entry's mapper to retrieve a signature for the social share image.
+     */
+    public function screenshotHashData(Entry $entry)
+    {
+        $mapper = app(CreatePageModel::class)->mapper($entry);
+
+        return [
+            $mapper->makeSocialShareViewName(),
+            $mapper->makeSocialShareViewData(),
+        ];
+    }
+
+    /**
+     * Create a lock to synchronise image generation.
+     *
+     * @template T
+     *
+     * @param null|callable(...$) : T  $callback
+     *
+     * @return ($callback is null ? \Illuminate\Contracts\Cache\Lock : T)
+     */
+    public function lock(?callable $callback = null)
+    {
+        $config = config('sitekit.social_share.lock');
+        $lock = Cache::lock($config['name'], $config['expiry_seconds']);
+
+        if (! $callback) {
+            return $lock;
+        }
+
+        return $lock->block($config['block_seconds'], $callback);
+    }
+
+    /**
+     * Spawn an instance of Chrome and takes a screenshot of the given URL. Notably, does not
+     * acquire a lock, this should be acquired separately.
+     */
+    public function screenshot(string $url)
+    {
+        $browser = $this->browser();
+        $page = $browser->createPage();
+
+        $page->navigate($url)->waitForNavigation();
+
+        return $page->screenshot([
+            'format' => 'webp',
+        ]);
+    }
+
+    /**
+     * Generates the internal render url of for the Entry.
+     */
+    public function htmlUrl(Entry $entry)
+    {
+        $host = url('');
+        $url = url()->signedRoute('sitekit.social-share.render', [
+            'id' => $entry->id(),
+        ]);
+
+        $path = str($url)->after($host);
+
+        return config('sitekit.social_share.render_url') . $path;
+    }
+
+    /**
+     * Creates an instance of Browser using factory.
+     */
+    public function browser(): ProcessAwareBrowser
+    {
+        return $this->browserFactory()->createBrowser([
+            'noSandbox' => true,
+            'windowSize' => explode('x', strval(config('sitekit.social_share.window_size')), 2),
+            'customFlags' => [
+                '--disable-dev-shm-usage',
+                '--disable-extensions',
+                '--js-flags="--max-old-space-size=128"',
+                '--preprender-from-omnibox',
+            ]
+        ]);
+    }
+
+    /**
+     * Create an instance of the Browser factory for Chrome.
+     */
+    public function browserFactory(): BrowserFactory
+    {
+        return new BrowserFactory(config('sitekit.social_share.chrome_path'));
+    }
+}

--- a/src/SocialShare/SocialShareServiceProvider.php
+++ b/src/SocialShare/SocialShareServiceProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace FewFar\Sitekit\SocialShare;
+
+use Illuminate\Support\Facades;
+use Illuminate\Support\ServiceProvider;
+
+class SocialShareServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register()
+    {
+        $this->registerListeners();
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot()
+    {
+        $this->configureCommands();
+        $this->configureRoutes();
+    }
+
+    /**
+     * Register module event listeners.
+     */
+    protected function registerListeners()
+    {
+        Facades\Event::subscribe(HandleImageCleanup::class);
+    }
+
+    /**
+     * Register console commands.
+     */
+    protected function configureCommands()
+    {
+        $this->commands([
+            CleanupCommand::class,
+        ]);
+    }
+
+    /**
+     * Register routes for the module.
+     */
+    protected function configureRoutes()
+    {
+        if (! config('sitekit.social_share.enable')) {
+            return;
+        }
+
+        Facades\Route::middleware('web')->group(function () {
+            Facades\Route::get('/!/social-share/entries/{id}/social-share.webp', ImageController::class)
+                ->unless(app()->isLocal())
+                ->middleware('signed')
+                ->name('sitekit.social-share');
+
+            Facades\Route::get('/!/social-share/entries/{id}/social-share', HtmlController::class)
+                ->unless(app()->isLocal())
+                ->middleware('signed')
+                ->name('sitekit.social-share.render');
+        });
+    }
+}

--- a/src/ViewModels/Concerns/MakesSocialShareView.php
+++ b/src/ViewModels/Concerns/MakesSocialShareView.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace FewFar\Sitekit\ViewModels\Concerns;
+
+trait MakesSocialShareView
+{
+    /**
+     * Creates an instance of the Mapper's social share view, if any.
+     */
+    public function socialShareView()
+    {
+        if (! $view = $this->makeSocialShareViewName()) {
+            return null;
+        }
+
+        return view($view, $this->makeSocialShareViewData());
+    }
+
+    /**
+     * Controls which view should be used to render the Social Share image. Use `null` to
+     * disable this functionality for this Mapper, or override `makeSocialShareViewName`
+     * to control which template is used on a per entry basis.
+     *
+     * @var string|null
+     */
+    protected $socialShareViewName = 'social-share';
+
+    /**
+     * Name of the social share view.
+     */
+    public function makeSocialShareViewName()
+    {
+        return $this->socialShareViewName;
+    }
+
+    /**
+     * Data for the social share view.
+     */
+    public function makeSocialShareViewData()
+    {
+        return [
+            'model' => values($this->makeSocialShareViewModel()),
+        ];
+    }
+
+    public function makeSocialShareViewModel()
+    {
+        return [
+            'label' => $this->values->page_share_image_label ?: $this->values->page_label,
+            'heading' => $this->values->page_share_image_heading ?: $this->values->page_share_title ?: $this->values->page_heading ?: $this->values->title,
+            'description' => $this->values->page_share_image_description ?: $this->values->page_share_description ?: $this->values->html('page_excerpt'),
+        ];
+    }
+}

--- a/src/ViewModels/Listeners/CreatePageModel.php
+++ b/src/ViewModels/Listeners/CreatePageModel.php
@@ -15,7 +15,7 @@ class CreatePageModel
 
     public function ignoreRouteMappers(bool $ignore)
     {
-        $this->ignoreRouteMappers = true;
+        $this->ignoreRouteMappers = $ignore;
 
         return $this;
     }

--- a/src/ViewModels/Mapper.php
+++ b/src/ViewModels/Mapper.php
@@ -10,17 +10,23 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades;
 use Statamic\Structures\Page;
 use Composer\Semver\VersionParser;
+use FewFar\Sitekit\SocialShare\ImageGenerator;
 
 abstract class Mapper
 {
-    use Concerns\MakesMeta;
+    use Concerns\MakesMeta {
+        makeMetaSocialImage as _makeMetaSocialImage;
+    }
+    use Concerns\MakesSocialShareView;
 
     public Entry $entry;
+    public Values $values;
     public PageModel $model;
 
     public function setEntry(Entry $entry)
     {
         $this->entry = $entry;
+        $this->values = values($entry);
 
         return $this;
     }
@@ -212,5 +218,25 @@ abstract class Mapper
         $fields = values($entry)->collect('blocks');
 
         return $this->toComponentsFromFields($fields);
+    }
+
+    public function makeMetaSocialImage()
+    {
+        if ($explicit = $this->_makeMetaSocialImage()) {
+            return $explicit;
+        }
+
+        if (! config('sitekit.social_share.enabled')) {
+            return null;
+        }
+
+        if (! $this->makeSocialShareViewName()) {
+            return null;
+        }
+
+        return url()->signedRoute('sitekit.social-share', [
+            'id' => $this->entry->id(),
+            'hash' => app(ImageGenerator::class)->screenshotHash($this->entry),
+        ]);
     }
 }


### PR DESCRIPTION
This submodule takes advantage of the https://github.com/chrome-php/chrome PHP Package to generate social images.

Requires this in the docker images:

```
# Headless Chrome
## Alpine
RUN apk add linux-headers chromium \
    && docker-php-ext-install sockets \
    && apk del linux-headers

## Debian / Ubuntu
RUN apt-get update && apt-get install -y chromium \
    && install-php-extensions sockets
```

Provides routes:

- `/!/social-share/entries/{id}/social-share.webp`
  Spins up an instance of chrome, visits the route below, takes a screenshot then streams the response
- `/!/social-share/entries/{id}/social-share`
  Loads the social-share.blade.php with the model data from the entry's mapper.

If using Caddy recommendation to use this optimisation:

```
@social-share-path path_regexp asset ^/!/social-share/(entries/\d+)/social-share\.webp$
handle @social-share-path {
	@social-share-exist file {
		root /var/www
		try_files /storage/app/private/social-share/{re.asset.1}/{query.hash}.webp
	}

	handle @social-share-exist {
		root /var/www
		rewrite * /storage/app/private/social-share/{re.asset.1}/{query.hash}.webp
		import static-cache
		file_server
	}
}
```

Outstanding tasks:

- [x] Store the generated images to the filesystem
- [x] Determine a system for invalidation of saves images (just listen to `EntrySaved` perhaps?)
- [x] Provide system to disable this submodule?
- [x] Implement non-DB based locking to synchronise creation of the Browser socket to prevent new instances being created. Reason for non-DB based locking is because each container gets its own Browser instance, so all PHP processes within the same container will share, but the DB is application wide i.e. there might be more than one container in a given service. Ideal is just to use a filesystem lock but make a space on the container FS that is viable for writing.
- [x] Make the module semi-opt-in:
  - Opt-out from the config
  - Out-in by needing a social-share.blade.php or equivalent for the mapper.