### PR TITLE
Adding the bard function to the collection seeder

### DIFF
--- a/src/Database/Seeders/CollectionSeeder.php
+++ b/src/Database/Seeders/CollectionSeeder.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Statamic\Entries\Collection;
 use Statamic\Facades;
 use Statamic\Structures\CollectionTree;
+use Statamic\Fieldtypes\Bard;
 
 class CollectionSeeder extends Seeder
 {
@@ -173,6 +174,36 @@ class CollectionSeeder extends Seeder
                 $this->seed($item->children);
             }
         }
+    }
+
+    public function bard(?string $attribute, ?string $blueprint = null)
+    {
+        $bard = $this->collection()
+            ->entryBlueprint($blueprint)
+            ->field($attribute)
+            ->fieldtype();
+
+        return new class($bard) {
+            public function __construct(public Bard $bard)
+            {
+            }
+
+            public function make(iterable $items)
+            {
+                return collect($items)
+                    ->flatMap(fn ($item) => match (true) {
+                        is_string($item) => $this->bard->preProcess($item),
+                        is_array($item) => [
+                            [
+                                'type' => 'set',
+                                'attrs' => [ 'values' => $item ],
+                            ],
+                        ],
+                        default => throw new Exception('Unexpected type for $item, only strings (as html) and sets (blocks) are supported.')
+                    })
+                    ->all();
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Really useful when seeding text heavy pages and you'd like to include some HTML:

Usage example:

```
class NewsSeeder extends CollectionSeeder
{
    protected function fixtures()
    {
        return [
            'news-e' => [
                'title' => 'Celebrating Progress and Leadership at Our Annual Medical Advisory Board Meeting',
                'rich_text_content' => $this->bard('rich_text_content')->make(items: [
                    <<<'HTML'
                        <h2>Guiding Our Work</h2>
                        <p>We were proud to recently host the Eczema UK Annual Medical Advisory Board (MAB) meeting, an important opportunity to bring together expert voices from across dermatology to guide our work.</p>
                        <h3>The Highlights</h3>
                        <p>Since its founding in 2021, the MAB has played a vital role in shaping our organisational strategy, research priorities, and campaigning, and we’re deeply grateful for the continued insight and commitment of its members.</p>
                        <p>This year’s meeting was an energising and collaborative session, allowing us to:</p>
                        <ul>
                            <li>Share updates on the eczema research projects we’re funding through our growing grants programme.</li>
                            <li>Explore emerging developments in the medical and research landscape.</li>
                            <li>Reflect on the reach and impact of the trusted health information we provide for people living with eczema.</li>
                        </ul>
                    HTML,
                    [
                        'type' => 'call_to_actions',
                        'call_to_actions' => [
                            [
                                'link' => [
                                    'url' => '/about-us/medical-advisory-board',
                                    'label' => 'Medical Advisory Team',
                                    'option' => 'url',
                                ],
                                'type' => 'call_to_action',
                            ],
                            [
                                'link' => [
                                    'url' => '/about-us/our-team',
                                    'label' => 'Staff Team',
                                    'option' => 'url',
                                ],
                                'type' => 'call_to_action',
                            ]
                        ],
                    ],
                    <<<'HTML'
                        <h3>Important Changes</h3>
                        <p>We’re also marking an important moment in the MAB’s leadership. After four years as inaugural Chair, Professor Celia Moss OBE is stepping down from the role, we’re delighted she will remain on the Board as an active member</p>
                        <p>Celia has helped to shape the MAB from the start, ensuring it reflects the needs of both clinicians and the eczema community. We are incredibly grateful for her guidance, experience and unwavering support.</p>
                        <p>We’re equally pleased to announce that Professor Carsten Flohr will now take on the role of Chair.</p>
                        <p>A leading figure in eczema research and clinical care, Carsten is currently in the second year of his second three-year term on the MAB. He brings extensive academic and strategic leadership, and as head of a severe eczema clinic, he sees first-hand how devastating this condition can be</p>
                        <p>We are hugely thankful to Professor Flohr for stepping into this important role and for the expertise he continues to share.</p>
                        <hr>
                        <h2>Block test</h2>
                    HTML,
                ]),
            ],
        ];
    }
}
```